### PR TITLE
Fix Favorite Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Status Code: 200
 Status Code: 404
 ```json
 {
-  "message": "Favorite does not exist!"
+  "message": "Favorite with that ID does not exist!"
 }
 ```
 
@@ -131,7 +131,7 @@ Status Code: 204
 Status Code: 404
 ```json
 {
-  "message": "Favorite does not exist!"
+  "message": "Favorite with that ID does not exist!"
 }
 ```
 

--- a/db/seeds/dev/favorites.js
+++ b/db/seeds/dev/favorites.js
@@ -5,10 +5,10 @@ exports.seed = function(knex) {
     .then(function () {
       // Inserts seed entries
       return knex('favorites').insert([
-        {id: 1, title: 'Take On Me', artistName: 'a-ha', rating: 87, genre: 'Pop'},
-        {id: 2, title: 'Coming Home', artistName: 'Leon Bridges', rating: 90, genre: 'Soul'},
-        {id: 3, title: 'Africa', artistName: 'Toto', rating: 92},
-        {id: 4, title: 'Fur Elise', artistName: 'Ludwig Van Beethoven'}
+        { title: 'Take On Me', artistName: 'a-ha', rating: 87, genre: 'Pop' },
+        { title: 'Coming Home', artistName: 'Leon Bridges', rating: 90, genre: 'Soul' },
+        { title: 'Africa', artistName: 'Toto', rating: 92 },
+        { title: 'Fur Elise', artistName: 'Ludwig Van Beethoven' }
       ]);
     });
 };

--- a/lib/controllers/favorites_controller.js
+++ b/lib/controllers/favorites_controller.js
@@ -15,7 +15,7 @@ const show = (request, response) => {
   Favorite.find(request.params.id)
     .then((favorite) => {
       favorite ? response.status(200).json(favorite)
-               : response.status(404).json("There are no Favorites with that ID")
+               : response.status(404).json(noRecordResponse());
     })
     .catch((error) => {
       console.log(error)
@@ -35,7 +35,7 @@ const destroy = async (req, res) => {
   Favorite.destroy(favoriteId)
     .then((deleted) => { 
       deleted ? res.status(204).send() 
-              : res.status(404).send({ message: "Favorite does not exist!" });
+              : res.status(404).send(noRecordResponse());
     })
     .catch(error => {
       res.status(500).json({ error }); 
@@ -54,6 +54,10 @@ async function createFavorite(response, musix) {
 
 async function invalidResponse(response) {
   response.status(400).json({ message: "Invalid request body" })
+}
+
+const noRecordResponse = () => {
+  return { message: "Favorite with that ID does not exist!" }
 }
 
 const favoriteParams = (params) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,45 +762,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bl": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.4.2.tgz",
-      "integrity": "sha1-XbMdcvA4xU5orcOVeBJf47Ct3JY=",
-      "requires": {
-        "readable-stream": "~1.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1013,11 +974,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1126,7 +1082,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1187,15 +1144,6 @@
             "webidl-conversions": "^4.0.2"
           }
         }
-      }
-    },
-    "deasync": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-      "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
       }
     },
     "debug": {
@@ -1404,7 +1352,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.12.0",
@@ -1695,11 +1644,6 @@
       "requires": {
         "bser": "^2.0.0"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2510,21 +2454,6 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-      "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-      "requires": {
-        "ansi-regex": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        }
       }
     },
     "has-flag": {
@@ -3867,11 +3796,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
-    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -4393,55 +4317,6 @@
         "ipaddr.js": "1.9.0"
       }
     },
-    "pryjs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pryjs/-/pryjs-1.0.3.tgz",
-      "integrity": "sha1-msqACY7l3edrenu2047CrHIJR80=",
-      "requires": {
-        "chalk": "^0.5.1",
-        "coffee-script": "^1.8.0",
-        "deasync": "~0.1.2",
-        "pygmentize-bundled": "^2.3.0",
-        "underscore": "^1.7.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "requires": {
-            "ansi-regex": "^0.2.1"
-          }
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-        }
-      }
-    },
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
@@ -4463,15 +4338,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "pygmentize-bundled": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pygmentize-bundled/-/pygmentize-bundled-2.3.0.tgz",
-      "integrity": "sha1-1CXe2o0TaXW5M+3jYxNfYjNQgUo=",
-      "requires": {
-        "bl": "~0.4.1",
-        "through2": "~0.2.1"
-      }
     },
     "qs": {
       "version": "6.9.0",
@@ -5322,51 +5188,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
-    "through2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-      "requires": {
-        "readable-stream": "~1.1.9",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
     "tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -5489,11 +5310,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-    },
-    "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "knex": "^0.19.5",
     "morgan": "~1.9.1",
     "node-fetch": "^2.6.0",
-    "pg": "^7.8.0",
-    "pryjs": "^1.0.3"
+    "pg": "^7.8.0"
   },
   "devDependencies": {
     "babel-jest": "^24.9.0",

--- a/tests/requests/api/v1/favorites/delete.spec.js
+++ b/tests/requests/api/v1/favorites/delete.spec.js
@@ -44,7 +44,7 @@ describe('Test the favorites path', () => {
       
       expect(res.statusCode).toBe(404);
       expect(res.body).toHaveProperty('message');
-      expect(res.body.message).toBe('Favorite does not exist!');
+      expect(res.body.message).toBe("Favorite with that ID does not exist!");
 
       const favorites = await database('favorites').select()
       expect(favorites.length).toBe(1);

--- a/tests/requests/api/v1/favorites/show.spec.js
+++ b/tests/requests/api/v1/favorites/show.spec.js
@@ -48,7 +48,7 @@ describe('Test the favorites path', () => {
         .get(`/api/v1/favorites/9999`)
 
       expect(res.statusCode).toBe(404);
-      expect(res.body).toBe('There are no Favorites with that ID');
+      expect(res.body.message).toBe("Favorite with that ID does not exist!");
     });
   });
 });


### PR DESCRIPTION
Fixed a bug due to seed file of favorites creation. When the seed file is ran with explicitly declared IDs, the internal ID counter does not increment in knex. This led to an error in production/development where the user would try to create a new favorite via `POST /api/v1/favorites` and could not create a new favorite since ID 1 was taken already. 

This error would remedy itself if the user continued to make post requests until the internal knex ID counter incremented enough to pass the defined seed IDs. 

Also updated README and standardized No matching record responses.