### PR TITLE
Reformat Favorites show/index endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ All endpoints require the following headers:
 Returns a list of all favorites
 
 **Successful Response**
+
+Status Code: 200
 ```json
 [
   {
@@ -45,7 +47,19 @@ Returns a list of all favorites
 ]
 ```
 
+Successful response with no favorites in the database:
+```json
+[]
+```
+
 **Unsuccessful Response**
+
+Status Code: 500
+```json
+{
+  "message": "<REASON>"
+}
+```
 
 ---
 

--- a/lib/controllers/favorites_controller.js
+++ b/lib/controllers/favorites_controller.js
@@ -12,21 +12,8 @@ const index = (request, response) => {
     })
 }
 
-const show = (request, response) => {
-  favoriteId = request.params.id;
-  console.log(favoriteId)
-  if (isNaN(favoriteId)) {
-    return response.status(500).json({ message: "ID must be a number!" });
-  }
-  Favorite.find(favoriteId)
-    .then((favorite) => {
-      favorite ? response.status(200).json(formatPayload(favorite))
-               : response.status(404).json(noRecordResponse());
-    })
-    .catch((error) => {
-      console.log(error)
-      response.status(404).json({ error });
-    })
+const show = (req, res) => {
+  isNaN(req.params.id) ? invalidQueryId(req, res) : showFavorite(req, res);
 }
 
 const create = async (req, res) => {
@@ -37,15 +24,16 @@ const create = async (req, res) => {
 }
 
 const destroy = async (req, res) => {
-  favoriteId = req.params.id
-  Favorite.destroy(favoriteId)
-    .then((deleted) => { 
-      deleted ? res.status(204).send() 
-              : res.status(404).send(noRecordResponse());
-    })
-    .catch(error => {
-      res.status(500).json({ error }); 
-    })
+  isNaN(req.params.id) ? invalidQueryId(req, res) : deleteFavorite(req, res);
+  // favoriteId = req.params.id
+  // Favorite.destroy(req.params.id)
+  //   .then((deleted) => { 
+  //     deleted ? res.status(204).send() 
+  //             : res.status(404).send(noRecordResponse());
+  //   })
+  //   .catch(error => {
+  //     res.status(500).json({ error }); 
+  //   })
 }
 
 async function createFavorite(response, musix) {
@@ -64,6 +52,32 @@ async function invalidResponse(response) {
 
 const noRecordResponse = () => {
   return { message: "Favorite with that ID does not exist!" }
+}
+
+async function invalidQueryId(request, response) {
+  response.status(500).json({ message: "ID must be a number!" });
+}
+
+async function showFavorite(request, response) {
+  Favorite.find(request.params.id)
+    .then((favorite) => {
+      favorite ? response.status(200).json(formatPayload(favorite))
+               : response.status(404).json(noRecordResponse());
+    })
+    .catch((error) => {
+      response.status(404).json({ error });
+    })
+}
+
+async function deleteFavorite(request, response) {
+  Favorite.destroy(request.params.id)
+    .then((deleted) => { 
+      deleted ? response.status(204).send() 
+              : response.status(404).send(noRecordResponse());
+    })
+    .catch(error => {
+      response.status(500).json({ error }); 
+    })
 }
 
 const favoriteParams = (params) => {

--- a/lib/controllers/favorites_controller.js
+++ b/lib/controllers/favorites_controller.js
@@ -4,6 +4,7 @@ const musixMatchService = require('../services/musix_match_service')
 const index = (request, response) => {
   Favorite.all()
     .then((favorites) => {
+      favorites.forEach(favorite => formatPayload(favorite));
       response.status(200).json(favorites);
     })
     .catch((error) => {

--- a/lib/controllers/favorites_controller.js
+++ b/lib/controllers/favorites_controller.js
@@ -14,7 +14,7 @@ const index = (request, response) => {
 const show = (request, response) => {
   Favorite.find(request.params.id)
     .then((favorite) => {
-      favorite ? response.status(200).json(favorite)
+      favorite ? response.status(200).json(formatPayload(favorite))
                : response.status(404).json(noRecordResponse());
     })
     .catch((error) => {
@@ -67,6 +67,12 @@ const favoriteParams = (params) => {
     genre: params.primary_genres.music_genre_list[0].music_genre.music_genre_name,
     rating: params.track_rating
   }
+}
+
+const formatPayload = (favorite) => {
+  delete favorite.created_at;
+  delete favorite.updated_at;
+  return favorite;
 }
 
 module.exports = {

--- a/lib/controllers/favorites_controller.js
+++ b/lib/controllers/favorites_controller.js
@@ -13,7 +13,12 @@ const index = (request, response) => {
 }
 
 const show = (request, response) => {
-  Favorite.find(request.params.id)
+  favoriteId = request.params.id;
+  console.log(favoriteId)
+  if (isNaN(favoriteId)) {
+    return response.status(500).json({ message: "ID must be a number!" });
+  }
+  Favorite.find(favoriteId)
     .then((favorite) => {
       favorite ? response.status(200).json(formatPayload(favorite))
                : response.status(404).json(noRecordResponse());

--- a/lib/controllers/favorites_controller.js
+++ b/lib/controllers/favorites_controller.js
@@ -25,15 +25,6 @@ const create = async (req, res) => {
 
 const destroy = async (req, res) => {
   isNaN(req.params.id) ? invalidQueryId(req, res) : deleteFavorite(req, res);
-  // favoriteId = req.params.id
-  // Favorite.destroy(req.params.id)
-  //   .then((deleted) => { 
-  //     deleted ? res.status(204).send() 
-  //             : res.status(404).send(noRecordResponse());
-  //   })
-  //   .catch(error => {
-  //     res.status(500).json({ error }); 
-  //   })
 }
 
 async function createFavorite(response, musix) {

--- a/tests/requests/api/v1/favorites/delete.spec.js
+++ b/tests/requests/api/v1/favorites/delete.spec.js
@@ -38,16 +38,22 @@ describe('Test the favorites path', () => {
       expect(favorites.length).toBe(0);
     });
     
-    it('sad path', async () => {
-      const res = await request(app)
-      .delete(`/api/v1/favorites/9999`)
-      
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toHaveProperty('message');
-      expect(res.body.message).toBe("Favorite with that ID does not exist!");
+    describe('sad path', () => {
+      it('id does not exist in database', async () => {
+        const res = await request(app)
+          .delete(`/api/v1/favorites/9999`)
+  
+        expect(res.statusCode).toBe(404);
+        expect(res.body.message).toBe('Favorite with that ID does not exist!');
+      });
 
-      const favorites = await database('favorites').select()
-      expect(favorites.length).toBe(1);
+      it('id must be a number', async () => {
+        const res = await request(app)
+          .delete(`/api/v1/favorites/asdf`)
+  
+        expect(res.statusCode).toBe(500)
+        expect(res.body.message).toBe("ID must be a number!")
+      })
     });
   });
 });

--- a/tests/requests/api/v1/favorites/index.spec.js
+++ b/tests/requests/api/v1/favorites/index.spec.js
@@ -48,6 +48,8 @@ describe('Test the favorites path', () => {
       expect(res.body[0].genre).toBe('Rock');
       expect(res.body[0]).toHaveProperty('rating');
       expect(res.body[0].rating).toBe(88);
+      expect(res.body[0]).not.toHaveProperty('created_at');
+      expect(res.body[0]).not.toHaveProperty('updated_at');
 
       expect(res.body[1]).toHaveProperty('id');
       expect(res.body[1]).toHaveProperty('title');
@@ -58,6 +60,8 @@ describe('Test the favorites path', () => {
       expect(res.body[1].genre).toBe('Rock');
       expect(res.body[1]).toHaveProperty('rating');
       expect(res.body[1].rating).toBe(100);
+      expect(res.body[1]).not.toHaveProperty('created_at');
+      expect(res.body[1]).not.toHaveProperty('updated_at');
     });
   });
 });

--- a/tests/requests/api/v1/favorites/show.spec.js
+++ b/tests/requests/api/v1/favorites/show.spec.js
@@ -51,7 +51,7 @@ describe('Test the favorites path', () => {
           .get(`/api/v1/favorites/9999`)
   
         expect(res.statusCode).toBe(404);
-        expect(res.body).toBe('There are no Favorites with that ID');
+        expect(res.body.message).toBe('Favorite with that ID does not exist!');
       });
 
       it('id must be a number', async () => {

--- a/tests/requests/api/v1/favorites/show.spec.js
+++ b/tests/requests/api/v1/favorites/show.spec.js
@@ -45,12 +45,22 @@ describe('Test the favorites path', () => {
       expect(res.body).not.toHaveProperty('updated_at');
     });
 
-    it('sad path', async () => {
-      const res = await request(app)
-        .get(`/api/v1/favorites/9999`)
+    describe('sad path', () => {
+      it('id does not exist in database', async () => {
+        const res = await request(app)
+          .get(`/api/v1/favorites/9999`)
+  
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toBe('There are no Favorites with that ID');
+      });
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body.message).toBe("Favorite with that ID does not exist!");
+      it('id must be a number', async () => {
+        const res = await request(app)
+          .get(`/api/v1/favorites/asdf`)
+  
+        expect(res.statusCode).toBe(500)
+        expect(res.body.message).toBe("ID must be a number!")
+      })
     });
   });
 });

--- a/tests/requests/api/v1/favorites/show.spec.js
+++ b/tests/requests/api/v1/favorites/show.spec.js
@@ -41,6 +41,8 @@ describe('Test the favorites path', () => {
       expect(res.body.genre).toBe('Rock');
       expect(res.body).toHaveProperty('rating');
       expect(res.body.rating).toBe(88);
+      expect(res.body).not.toHaveProperty('created_at');
+      expect(res.body).not.toHaveProperty('updated_at');
     });
 
     it('sad path', async () => {


### PR DESCRIPTION
* Removed the created/updated_at attributes from `GET /api/v1/favorites` and `GET /api/v1/favorites/:id`
* Add validations to Favorite show/delete for whether the query ID is a number

closes #21 