### PR TITLE
Playlist-Favorites Delete Endpoint

### DIFF
--- a/lib/controllers/playlists/favoritesController.js
+++ b/lib/controllers/playlists/favoritesController.js
@@ -10,9 +10,9 @@ const create = async (req, res) => {
   const playlistId = req.params.playlist_id
   const favoriteId = req.params.favorite_id
 
-  if (isNaN(playlistId) || isNaN(favoriteId)) { 
+  if (isNaN(playlistId) || isNaN(favoriteId)) {
     console.log('HERERASDFASDF')
-    return res.status(400).json({ message: "ID must be a number!" }); 
+    return res.status(400).json({ message: "ID must be a number!" });
   }
   let playlist = await database('playlists')
     .where({id: playlistId}).first()
@@ -38,6 +38,34 @@ const create = async (req, res) => {
 }
 
 const destroy = async (req, res) => {
+  const playlistId = req.params.playlist_id
+  const favoriteId = req.params.favorite_id
+
+  if (isNaN(playlistId) || isNaN(favoriteId)) {
+    return res.status(400).json({ message: "ID must be a number!" });
+  }
+  let playlist = await database('playlists')
+    .where({id: playlistId}).first()
+  let favorite = await database('favorites')
+    .where({id: favoriteId}).first()
+
+  if (favorite === undefined || playlist === undefined) {
+    return res.status(404).json({ message: "Playlist or Favorite with that ID does not exist!"})
+  } else {
+    database('playlist_favorites')
+      .where({
+        playlistId: playlist.id,
+        favoriteId: favorite.id
+      })
+      .del()
+      .then(() =>{
+        res.status(204).json()
+      })
+      .catch(error => {
+        console.log(error)
+        res.status(500).json({error: error})
+      })
+  }
 }
 
 

--- a/lib/routes/api/v1/playlists.js
+++ b/lib/routes/api/v1/playlists.js
@@ -9,4 +9,6 @@ router.put('/:id', playlistsController.update);
 router.delete('/:id', playlistsController.destroy);
 
 router.post('/:playlist_id/favorites/:favorite_id', favoritesController.create)
+router.delete('/:playlist_id/favorites/:favorite_id', favoritesController.destroy)
+
 module.exports = router

--- a/tests/requests/api/v1/playlists/favorites.spec.js
+++ b/tests/requests/api/v1/playlists/favorites.spec.js
@@ -43,12 +43,12 @@ describe('Test the Playlists path', () => {
 
       let favorites = await database('playlist_favorites').select()
       expect(favorites.length).toBe(1);
-      
+
       expect(res.statusCode).toBe(201);
       expect(res.body).toHaveProperty('Success');
       expect(res.body.Success).toBe(`${favorite.title} has been added to ${playlist.title}!`);
     });
-    
+
     it('id does not exist in database', async () => {
       const res = await request(app)
       .post('/api/v1/playlists/9999/favorites/9999')
@@ -60,6 +60,38 @@ describe('Test the Playlists path', () => {
     it('id must be a number', async () => {
       const res = await request(app)
       .post('/api/v1/playlists/asdf/favorites/asdf')
+
+      expect(res.statusCode).toBe(400)
+      expect(res.body.message).toBe("ID must be a number!")
+    })
+  });
+
+  describe('Test Favorite Deletion', () => {
+    it('happy path', async () => {
+      const playlist = await database('playlists').select().first()
+      const favorite = await database('favorites').select().first()
+      await database('playlist_favorites').insert({playlistId: playlist.id, favoriteId: favorite.id}, 'id')
+
+      const res = await request(app)
+        .delete(`/api/v1/playlists/${playlist.id}/favorites/${favorite.id}`)
+
+      let favorites = await database('playlist_favorites').select()
+      expect(favorites.length).toBe(0);
+
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('id does not exist in database', async () => {
+      const res = await request(app)
+      .delete('/api/v1/playlists/9999/favorites/9999')
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toBe('Playlist or Favorite with that ID does not exist!');
+    });
+
+    it('id must be a number', async () => {
+      const res = await request(app)
+      .delete('/api/v1/playlists/asdf/favorites/asdf')
 
       expect(res.statusCode).toBe(400)
       expect(res.body.message).toBe("ID must be a number!")

--- a/tests/requests/api/v1/playlists/favorites.spec.js
+++ b/tests/requests/api/v1/playlists/favorites.spec.js
@@ -12,7 +12,6 @@ describe('Test the Playlists path', () => {
     await database.raw('truncate table playlists cascade');
     await database.raw('truncate table favorites cascade');
 
-    await database('playlists').insert({ "title": "Coding Vibes" }, 'id');
     let favoriteData_1 = {
       "title": "We Will Rock You",
       "artistName": "Queen",
@@ -25,6 +24,7 @@ describe('Test the Playlists path', () => {
       "genre": "Rock",
       "rating": 100
     }
+    await database('playlists').insert({ title: "Coding Vibes" }, 'id');
     await database('favorites').insert(favoriteData_1, 'id');
     await database('favorites').insert(favoriteData_2, 'id');
   });


### PR DESCRIPTION
Endpoint `DELETE api/v1/playlists/:id/favorites/:id` 
Deletes playlist_favorites Table record corresponding with the two specified `:id`s
Tests Passing

closes #41 